### PR TITLE
Workbench and card tooltips 1

### DIFF
--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -759,6 +759,7 @@ MonoBehaviour:
   partType: 6
   bankText: {fileID: 1343919372}
   sellButton: {fileID: 198065689}
+  sellButtonText: {fileID: 1835960740}
 --- !u!212 &266640589
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -1677,6 +1678,7 @@ MonoBehaviour:
   partType: 6
   bankText: {fileID: 2011563591}
   sellButton: {fileID: 1876394394}
+  sellButtonText: {fileID: 1202430322}
 --- !u!212 &613597419
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -3139,6 +3141,96 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 988083652}
   m_CullTransparentMesh: 1
+--- !u!1 &1020556176
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1020556177}
+  - component: {fileID: 1020556179}
+  - component: {fileID: 1020556178}
+  - component: {fileID: 1020556180}
+  m_Layer: 5
+  m_Name: WorkbenchTooltipBox
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1020556177
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1020556176}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1744771302}
+  m_Father: {fileID: 1449179672}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 441.71323, y: 221.02637}
+  m_SizeDelta: {x: 120, y: 60}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &1020556178
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1020556176}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.3301887, g: 0.3301887, b: 0.3301887, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1020556179
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1020556176}
+  m_CullTransparentMesh: 1
+--- !u!114 &1020556180
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1020556176}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 31b146580bce64b2eade21c96762d1a8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  textComponent: {fileID: 1744771303}
 --- !u!1 &1042013181
 GameObject:
   m_ObjectHideFlags: 0
@@ -3329,7 +3421,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Button
+  m_text: SELL
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -3597,7 +3689,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Button
+  m_text: SELL
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -3875,6 +3967,7 @@ MonoBehaviour:
   partType: 6
   bankText: {fileID: 163644145}
   sellButton: {fileID: 1339494086}
+  sellButtonText: {fileID: 1955050247}
 --- !u!212 &1266363852
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -4511,6 +4604,7 @@ MonoBehaviour:
   partType: 6
   bankText: {fileID: 301548354}
   sellButton: {fileID: 1416570253}
+  sellButtonText: {fileID: 1100575064}
 --- !u!212 &1353454565
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -4938,6 +5032,108 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1416570251}
   m_CullTransparentMesh: 1
+--- !u!1 &1449179668
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1449179672}
+  - component: {fileID: 1449179671}
+  - component: {fileID: 1449179670}
+  - component: {fileID: 1449179669}
+  m_Layer: 5
+  m_Name: Tooltips
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1449179669
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1449179668}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &1449179670
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1449179668}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &1449179671
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1449179668}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &1449179672
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1449179668}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1020556177}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
 --- !u!1 &1452801732
 GameObject:
   m_ObjectHideFlags: 0
@@ -5401,6 +5597,140 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1707054656}
   m_CullTransparentMesh: 1
+--- !u!1 &1744771301
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1744771302}
+  - component: {fileID: 1744771304}
+  - component: {fileID: 1744771303}
+  m_Layer: 5
+  m_Name: WbTooltipText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1744771302
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1744771301}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1020556177}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -30, y: -20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1744771303
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1744771301}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: New Text
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 22.05
+  m_fontSizeBase: 20
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 10
+  m_fontSizeMax: 30
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1744771304
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1744771301}
+  m_CullTransparentMesh: 1
 --- !u!1 &1793509550
 GameObject:
   m_ObjectHideFlags: 0
@@ -5634,7 +5964,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Button
+  m_text: SELL
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -6033,7 +6363,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Button
+  m_text: SELL
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -6390,3 +6720,4 @@ SceneRoots:
   - {fileID: 714590093}
   - {fileID: 552334780}
   - {fileID: 259174248}
+  - {fileID: 1449179672}

--- a/Assets/Scripts/Bank.cs
+++ b/Assets/Scripts/Bank.cs
@@ -4,6 +4,7 @@ using TMPro;
 using Unity.VisualScripting;
 using UnityEngine;
 using UnityEngine.UI;
+using TMPro;
 
 public class Bank : MonoBehaviour
 {
@@ -23,6 +24,8 @@ public class Bank : MonoBehaviour
     // button to sell this workbench
     [SerializeField]
     private Button sellButton;
+    [SerializeField]
+    private TextMeshProUGUI sellButtonText;
 
     void Start()
     {
@@ -153,6 +156,14 @@ public class Bank : MonoBehaviour
                 if (bankData.Count >= 2)
                 {
                     sellButton.interactable = true;
+                    if(bankData[0].cardSuit == bankData[1].cardSuit)
+                    {
+                        sellButtonText.text = "SELL";
+                    }
+                    else if(bankData[0].cardValue == bankData[1].cardValue)
+                    {
+                        sellButtonText.text = "USE";
+                    }
                 }
             }
         }
@@ -251,5 +262,49 @@ public class Bank : MonoBehaviour
             Debug.Log("This workbench can't be sold yet");
             return false;
         }
+    }
+
+    private void OnMouseEnter()
+    {
+        string msg = string.Empty;
+        // Show Workbench info when mouse hover and no cards selected 
+        if (GameplayManager.Instance.selected_cards.Count == 0)
+        {
+            if (bankData.Count < 2)
+            {
+                msg += "Collect more parts to build a robot or a weapon!";
+            }
+            else
+            {
+                if (bankData[0].cardSuit == bankData[1].cardSuit)
+                {
+                    msg += "Building " + bankData[0].cardSuit + " robot...\n" + bankData.Count + " parts so far.";
+                }
+                else if (bankData[0].cardValue == bankData[1].cardValue)
+                {
+                    msg += "Building " + bankData[0].cardValue + " weapon...\n" + bankData.Count + " parts so far.";
+                }
+            }
+            TooltipManager._instance.SetAndShowTooltip(msg);
+        }
+        /*
+        else if(GameplayManager.Instance.selected_cards.Count == 1)
+        {
+            CardData selectedCardData = GameplayManager.Instance.selected_cards[0].GetCardData();
+            if (isValidAddition(selectedCardData))
+            {
+                TooltipManager._instance.SetAndShowTooltip("Click to add selected card.");
+            }
+            else
+            {
+                TooltipManager._instance.SetAndShowTooltip("Selected card cannot be added to this workbench.");
+            }
+        }
+        */
+    }
+
+    private void OnMouseExit()
+    {
+        TooltipManager._instance.HideTooltip();
     }
 }

--- a/Assets/Scripts/Card.cs
+++ b/Assets/Scripts/Card.cs
@@ -78,6 +78,25 @@ public class Card : MonoBehaviour
         return new CardData(cardValue, cardSuit, texture);
     }
 
+    // Mouseover Tooltip functions 
+    private void OnMouseEnter()
+    {
+        if (GameplayManager.Instance.selected_cards.Count == 0)
+        {
+            TooltipManager._instance.SetAndShowTooltip("Click to select this card.");
+        }
+        else if (GameplayManager.Instance.selected_cards.Count == 1 && GameplayManager.Instance.selected_cards[0] != this)
+        {
+            TooltipManager._instance.SetAndShowTooltip("Click to change to this card.");
+        }
+        
+    }
+
+    private void OnMouseExit()
+    {
+        TooltipManager._instance.HideTooltip();
+    }
+
     //when clicked, pass to gameplay manager to find it in the river or hand and bank it
     //when clicked, a card should be banked
     private void OnMouseDown()

--- a/Assets/Scripts/GameplayManager.cs
+++ b/Assets/Scripts/GameplayManager.cs
@@ -251,6 +251,7 @@ public class GameplayManager : MonoBehaviour
                 decrementActionsTaken();
                 //CheckRefreshRiver();
                 IncrementActivePlayer();
+                GameplayManager.Instance.selected_cards.Clear();
                 break;
 
             case 3:

--- a/Assets/Scripts/TooltipManager.cs
+++ b/Assets/Scripts/TooltipManager.cs
@@ -1,0 +1,67 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+public class TooltipManager : MonoBehaviour
+{
+    public static TooltipManager _instance;
+    public TextMeshProUGUI textComponent;
+    private RectTransform rectTransform;
+
+    private void Awake()
+    {
+        rectTransform = GetComponent<RectTransform>();
+        // Singleton pattern 
+        if (_instance != null && _instance != this)
+        {
+            Destroy(this.gameObject);
+        }
+        else
+        {
+            _instance = this;
+        }
+    }
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        Cursor.visible = true;
+        gameObject.SetActive(false);
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        Vector2 mousePos = Input.mousePosition;
+
+        float pivotX = 0;
+        float pivotY = 0;
+
+        if (mousePos.y < Screen.height * 0.2f)
+        {
+            pivotY = 1;
+        }
+
+        if (mousePos.x > Screen.width * 0.8f)
+        {
+            pivotX = 1;
+        }
+
+        rectTransform.pivot = new Vector2(pivotX, pivotY);
+        rectTransform.position = Input.mousePosition;
+    }
+
+    public void SetAndShowTooltip(string message)
+    {
+        gameObject.SetActive(true);
+        textComponent.text = message;
+    }
+
+    public void HideTooltip()
+    {
+        gameObject.SetActive(false);
+        textComponent.text = string.Empty;
+    }
+}

--- a/Assets/Scripts/TooltipManager.cs.meta
+++ b/Assets/Scripts/TooltipManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 31b146580bce64b2eade21c96762d1a8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Implemented first rendition of mouse-over tooltips for workbench and cards in river: displays messages depending on empty workbench or not, whether workbench contains robot or weapon and how many parts currently (plan on implementing workbench tooltip also displaying whether a selected card is a valid addition or not)
- Implemented workbench button text changing, based on a robot or weapon being built