### PR TITLE
minor change to workbench popups: checks if ability first

### DIFF
--- a/Assets/Scripts/Bank.cs
+++ b/Assets/Scripts/Bank.cs
@@ -285,14 +285,15 @@ public class Bank : MonoBehaviour
             }
             else
             {
-                if (bankData[0].cardSuit == bankData[1].cardSuit)
+                if (bankData[0].cardValue == bankData[1].cardValue)
+                {
+                    msg += "Building " + bankData[0].cardValue + " ability...\n" + bankData.Count + " parts so far.";
+                }
+                else if (bankData[0].cardSuit == bankData[1].cardSuit)
                 {
                     msg += "Building " + bankData[0].cardSuit + " robot...\n" + bankData.Count + " parts so far.";
                 }
-                else if (bankData[0].cardValue == bankData[1].cardValue)
-                {
-                    msg += "Building " + bankData[0].cardValue + " weapon...\n" + bankData.Count + " parts so far.";
-                }
+                
             }
             TooltipManager._instance.SetAndShowTooltip(msg);
         }


### PR DESCRIPTION
- fixed a minor issue where, when starting an ability pile with identical parts (i.e. two black left arms), the popup presented it as a robot in progress